### PR TITLE
Python pnnx release

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -1,0 +1,466 @@
+name: release
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  LIBTORCH_VERSION: 2.1.0
+  TORCHVISION_VERSION: 0.16.0
+  PROTOBUF_VERSION: 3.11.2
+  CACHE_DATE: 20231010
+
+permissions:
+  contents: read
+
+jobs:
+  macos-deps:
+    runs-on: macos-11
+    steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: pnnx-patches
+      uses: actions/checkout@v4
+      with:
+        path: pnnx-patches
+    - name: cache-libtorch
+      id: cache-libtorch
+      uses: actions/cache@v3.3.2
+      with:
+        path: "libtorch"
+        key: libtorch-${{ env.LIBTORCH_VERSION }}-macos-${{ env.CACHE_DATE }}
+    - name: libtorch
+      if: steps.cache-libtorch.outputs.cache-hit != 'true'
+      run: |
+        wget -q https://github.com/pytorch/pytorch/releases/download/v${{ env.LIBTORCH_VERSION }}/pytorch-v${{ env.LIBTORCH_VERSION }}.tar.gz
+        tar -xf pytorch-v${{ env.LIBTORCH_VERSION }}.tar.gz
+        cd pytorch-v${{ env.LIBTORCH_VERSION }}
+        pip3 install -r requirements.txt
+        patch -p1 -i $GITHUB_WORKSPACE/pnnx-patches/pytorch-v${{ env.LIBTORCH_VERSION }}-fix-mobile-build.patch
+        patch -p1 -i $GITHUB_WORKSPACE/pnnx-patches/pytorch-v${{ env.LIBTORCH_VERSION }}-no-link-system-lib.patch
+        mkdir -p build; cd build
+        cmake -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/libtorch" -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_SHARED_LIBS=OFF \
+            -DBUILD_CAFFE2_OPS=OFF \
+            -DBUILD_CUSTOM_PROTOBUF=OFF \
+            -DBUILD_LITE_INTERPRETER=OFF \
+            -DBUILD_PYTHON=OFF \
+            -DINTERN_BUILD_MOBILE=ON \
+            -DINTERN_DISABLE_AUTOGRAD=ON \
+            -DINTERN_DISABLE_ONNX=ON \
+            -DUSE_CUDA=OFF \
+            -DUSE_DISTRIBUTED=OFF \
+            -DUSE_ITT=OFF \
+            -DUSE_KINETO=OFF \
+            -DUSE_LITE_INTERPRETER_PROFILER=OFF \
+            -DUSE_MKLDNN=OFF \
+            -DUSE_NUMPY=OFF \
+            -DUSE_OPENMP=OFF \
+            -DUSE_SOURCE_DEBUG_ON_MOBILE=OFF \
+            -DUSE_XNNPACK=OFF \
+            ..
+        cmake --build . -j 3
+        cmake --build . --target install/strip
+    - name: cache-torchvision
+      id: cache-torchvision
+      uses: actions/cache@v3.3.2
+      with:
+        path: "torchvision"
+        key: torchvision-${{ env.TORCHVISION_VERSION }}-macos-${{ env.CACHE_DATE }}
+    - name: torchvision
+      if: steps.cache-torchvision.outputs.cache-hit != 'true'
+      run: |
+        wget -q https://github.com/pytorch/vision/archive/refs/tags/v${{ env.TORCHVISION_VERSION }}.zip -O vision-${{ env.TORCHVISION_VERSION }}.zip
+        unzip -q vision-${{ env.TORCHVISION_VERSION }}.zip
+        cd vision-${{ env.TORCHVISION_VERSION }}
+        patch -p1 -i $GITHUB_WORKSPACE/pnnx-patches/vision-${{ env.TORCHVISION_VERSION }}-ops-only.patch
+        patch -p1 -i $GITHUB_WORKSPACE/pnnx-patches/vision-${{ env.TORCHVISION_VERSION }}-no-cuda-version.patch
+        mkdir -p build; cd build
+        cmake -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/torchvision" -DTorch_DIR="$GITHUB_WORKSPACE/libtorch/share/cmake/Torch" -DCMAKE_BUILD_TYPE=MinSizeRel -DWITH_PNG=OFF -DWITH_JPEG=OFF ..
+        cmake --build . -j 3
+        cmake --build . --target install/strip
+    - name: cache-protobuf
+      id: cache-protobuf
+      uses: actions/cache@v3.3.2
+      with:
+        path: "protobuf"
+        key: protobuf-${{ env.PROTOBUF_VERSION }}-macos-${{ env.CACHE_DATE }}
+    - name: protobuf
+      if: steps.cache-protobuf.outputs.cache-hit != 'true'
+      run: |
+        wget -q https://github.com/protocolbuffers/protobuf/archive/v${{ env.PROTOBUF_VERSION }}.zip -O protobuf-${{ env.PROTOBUF_VERSION }}.zip
+        unzip -q protobuf-${{ env.PROTOBUF_VERSION }}.zip
+        cd protobuf-${{ env.PROTOBUF_VERSION }}
+        mkdir -p build2; cd build2;
+        cmake -DCMAKE_INSTALL_PREFIX="$GITHUB_WORKSPACE/protobuf" -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=MinSizeRel ../cmake
+        cmake --build . -j 3
+        cmake --build . --target install/strip
+
+  windows-deps:
+    runs-on: windows-2019
+    env:
+      UseMultiToolTask: true
+    steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: pnnx-patches
+      uses: actions/checkout@v4
+      with:
+        path: pnnx-patches
+    - name: cache-libtorch
+      id: cache-libtorch
+      uses: actions/cache@v3.3.2
+      with:
+        path: "libtorch"
+        key: libtorch-${{ env.LIBTORCH_VERSION }}-vs2019-${{ env.CACHE_DATE }}
+    - name: libtorch
+      if: steps.cache-libtorch.outputs.cache-hit != 'true'
+      run: |
+        Invoke-WebRequest -Uri https://github.com/pytorch/pytorch/releases/download/v${{ env.LIBTORCH_VERSION }}/pytorch-v${{ env.LIBTORCH_VERSION }}.tar.gz -OutFile pytorch-v${{ env.LIBTORCH_VERSION }}.tar.gz
+        7z x pytorch-v${{ env.LIBTORCH_VERSION }}.tar.gz
+        7z x pytorch-v${{ env.LIBTORCH_VERSION }}.tar
+        cd pytorch-v${{ env.LIBTORCH_VERSION }}
+        pip3 install -r requirements.txt
+        C:\msys64\usr\bin\patch.exe -p1 -i $env:GITHUB_WORKSPACE\pnnx-patches\pytorch-v${{ env.LIBTORCH_VERSION }}-fix-mobile-build.patch
+        C:\msys64\usr\bin\patch.exe -p1 -i $env:GITHUB_WORKSPACE\pnnx-patches\pytorch-v${{ env.LIBTORCH_VERSION }}-no-link-system-lib.patch
+        C:\msys64\usr\bin\patch.exe -p1 -i $env:GITHUB_WORKSPACE\pnnx-patches\pytorch-v${{ env.LIBTORCH_VERSION }}-set-python-executable.patch
+        C:\msys64\usr\bin\patch.exe -p1 -i $env:GITHUB_WORKSPACE\pnnx-patches\pytorch-v${{ env.LIBTORCH_VERSION }}-no-mimalloc.patch
+        mkdir -p build; cd build
+        cmake -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE/libtorch" -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_SHARED_LIBS=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded `
+            -DBUILD_CAFFE2_OPS=OFF `
+            -DBUILD_CUSTOM_PROTOBUF=OFF `
+            -DBUILD_LITE_INTERPRETER=OFF `
+            -DBUILD_PYTHON=OFF `
+            -DINTERN_BUILD_MOBILE=ON `
+            -DINTERN_DISABLE_AUTOGRAD=ON `
+            -DINTERN_DISABLE_ONNX=ON `
+            -DUSE_CUDA=OFF `
+            -DUSE_DISTRIBUTED=OFF `
+            -DUSE_ITT=OFF `
+            -DUSE_KINETO=OFF `
+            -DUSE_LITE_INTERPRETER_PROFILER=OFF `
+            -DUSE_MKLDNN=OFF `
+            -DUSE_NUMPY=OFF `
+            -DUSE_OPENMP=OFF `
+            -DUSE_SOURCE_DEBUG_ON_MOBILE=OFF `
+            -DUSE_XNNPACK=OFF `
+            ..
+        cmake --build . --config MinSizeRel -j 2
+        cmake --build . --config MinSizeRel --target install
+    - name: cache-torchvision
+      id: cache-torchvision
+      uses: actions/cache@v3.3.2
+      with:
+        path: "torchvision"
+        key: torchvision-${{ env.TORCHVISION_VERSION }}-vs2019-${{ env.CACHE_DATE }}
+    - name: torchvision
+      if: steps.cache-torchvision.outputs.cache-hit != 'true'
+      run: |
+        Invoke-WebRequest -Uri https://github.com/pytorch/vision/archive/refs/tags/v${{ env.TORCHVISION_VERSION }}.zip -OutFile vision-${{ env.TORCHVISION_VERSION }}.zip
+        7z x vision-${{ env.TORCHVISION_VERSION }}.zip
+        cd vision-${{ env.TORCHVISION_VERSION }}
+        C:\msys64\usr\bin\patch.exe -p1 -i $env:GITHUB_WORKSPACE\pnnx-patches\vision-${{ env.TORCHVISION_VERSION }}-ops-only.patch
+        C:\msys64\usr\bin\patch.exe -p1 -i $env:GITHUB_WORKSPACE\pnnx-patches\vision-${{ env.TORCHVISION_VERSION }}-no-cuda-version.patch
+        C:\msys64\usr\bin\patch.exe -p1 -i $env:GITHUB_WORKSPACE\pnnx-patches\vision-${{ env.TORCHVISION_VERSION }}-no-dll-export.patch
+        mkdir -p build; cd build
+        cmake -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE/torchvision" -DTorch_DIR="$env:GITHUB_WORKSPACE/libtorch/share/cmake/Torch" -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DWITH_PNG=OFF -DWITH_JPEG=OFF ..
+        cmake --build . --config MinSizeRel -j 2
+        cmake --build . --config MinSizeRel --target install
+    - name: cache-protobuf
+      id: cache-protobuf
+      uses: actions/cache@v3.3.2
+      with:
+        path: "protobuf"
+        key: protobuf-${{ env.PROTOBUF_VERSION }}-vs2019-${{ env.CACHE_DATE }}
+    - name: protobuf
+      if: steps.cache-protobuf.outputs.cache-hit != 'true'
+      run: |
+        Invoke-WebRequest -Uri https://github.com/protocolbuffers/protobuf/archive/v${{ env.PROTOBUF_VERSION }}.zip -OutFile protobuf-${{ env.PROTOBUF_VERSION }}.zip
+        7z x ./protobuf-${{ env.PROTOBUF_VERSION }}.zip
+        cd protobuf-${{ env.PROTOBUF_VERSION }}
+        mkdir -p build2; cd build2;
+        cmake -DCMAKE_INSTALL_PREFIX="$env:GITHUB_WORKSPACE/protobuf" -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_MSVC_STATIC_RUNTIME=ON -DCMAKE_BUILD_TYPE=MinSizeRel ../cmake
+        cmake --build . --config MinSizeRel -j 2
+        cmake --build . --config MinSizeRel --target install
+
+  ubuntu_x86_64:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+        
+    - name: checkout
+      uses: actions/checkout@v4
+        
+    - name: ncnn
+      uses: actions/checkout@v4
+      with:
+        repository: Tencent/ncnn
+        path: ncnn
+        
+    - name: Build wheel for manylinux
+      uses: pypa/cibuildwheel@v2.16.2
+      env:
+        CIBW_ARCHS_LINUX: "x86_64"
+        CIBW_BUILD: 'cp*-manylinux*'
+        CIBW_SKIP: cp36-* cp312-*
+        CIBW_BUILD_VERBOSITY: 1
+        CIBW_BEFORE_ALL: yum install protobuf-devel -y &&
+          yum install devtoolset-9 -y &&
+          yum install wget zip -y &&
+          wget -q https://github.com/pytorch/pytorch/releases/download/v${{ env.LIBTORCH_VERSION }}/pytorch-v${{ env.LIBTORCH_VERSION }}.tar.gz &&
+          tar -xf pytorch-v${{ env.LIBTORCH_VERSION }}.tar.gz &&
+          cd pytorch-v${{ env.LIBTORCH_VERSION }} &&
+          pip install -r requirements.txt &&
+          patch -p1 -i /project/pytorch-v${{ env.LIBTORCH_VERSION }}-fix-mobile-build.patch &&
+          patch -p1 -i /project/pytorch-v${{ env.LIBTORCH_VERSION }}-no-link-system-lib.patch &&
+          mkdir -p build && cd build &&
+          cmake -DCMAKE_INSTALL_PREFIX="/project/libtorch" -DCMAKE_BUILD_TYPE=MinSizeRel -DBUILD_SHARED_LIBS=OFF 
+              -DBUILD_CAFFE2_OPS=OFF 
+              -DBUILD_CUSTOM_PROTOBUF=OFF 
+              -DBUILD_LITE_INTERPRETER=OFF 
+              -DBUILD_PYTHON=OFF 
+              -DINTERN_BUILD_MOBILE=ON 
+              -DINTERN_DISABLE_AUTOGRAD=ON 
+              -DINTERN_DISABLE_ONNX=ON 
+              -DUSE_CUDA=OFF 
+              -DUSE_DISTRIBUTED=OFF 
+              -DUSE_ITT=OFF 
+              -DUSE_KINETO=OFF 
+              -DUSE_LITE_INTERPRETER_PROFILER=OFF 
+              -DUSE_MKLDNN=OFF 
+              -DUSE_NUMPY=OFF 
+              -DUSE_OPENMP=OFF 
+              -DUSE_SOURCE_DEBUG_ON_MOBILE=OFF 
+              -DUSE_XNNPACK=OFF 
+              -DCMAKE_CXX_COMPILER="/opt/rh/devtoolset-9/root/usr/bin/c++"
+              -DCMAKE_C_COMPILER="/opt/rh/devtoolset-9/root/usr/bin/cc"
+              .. &&
+          cmake --build . -j 2 &&
+          cmake --build . --target install/strip &&
+          cd /project/ &&
+          wget -q https://github.com/pytorch/vision/archive/refs/tags/v${{ env.TORCHVISION_VERSION }}.zip -O vision-${{ env.TORCHVISION_VERSION }}.zip &&
+          unzip -q vision-${{ env.TORCHVISION_VERSION }}.zip &&
+          cd vision-${{ env.TORCHVISION_VERSION }} &&
+          patch -p1 -i /project/vision-${{ env.TORCHVISION_VERSION }}-ops-only.patch  &&
+          patch -p1 -i /project/vision-${{ env.TORCHVISION_VERSION }}-no-cuda-version.patch  &&
+          mkdir -p build && cd build  &&
+          cmake -DCMAKE_INSTALL_PREFIX="/project/torchvision" 
+          -DTorch_DIR="/project/libtorch/share/cmake/Torch" 
+          -DCMAKE_BUILD_TYPE=MinSizeRel -DWITH_PNG=OFF 
+          -DCMAKE_C_COMPILER="/opt/rh/devtoolset-9/root/usr/bin/cc"
+          -DCMAKE_CXX_COMPILER="/opt/rh/devtoolset-9/root/usr/bin/c++" -DWITH_JPEG=OFF ..  &&
+          cmake --build . -j 2  &&
+          cmake --build . --target install/strip  &&
+          cd /project/ &&
+          wget -q https://github.com/protocolbuffers/protobuf/archive/v${{ env.PROTOBUF_VERSION }}.zip -O protobuf-${{ env.PROTOBUF_VERSION }}.zip &&
+          unzip -q protobuf-${{ env.PROTOBUF_VERSION }}.zip &&
+          cd protobuf-${{ env.PROTOBUF_VERSION }} &&
+          mkdir -p build2 && cd build2 &&
+          cmake -DCMAKE_INSTALL_PREFIX="/project/protobuf" -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_C_COMPILER="/opt/rh/devtoolset-9/root/usr/bin/cc"
+          -DCMAKE_CXX_COMPILER="/opt/rh/devtoolset-9/root/usr/bin/c++" -DCMAKE_BUILD_TYPE=MinSizeRel ../cmake &&
+          cmake --build . -j 2 &&
+          cmake --build . --target install/strip &&
+          cd /project/ncnn/tools/pnnx/ &&
+          mkdir build && cd build &&
+          cmake -DCMAKE_INSTALL_PREFIX=install -DCMAKE_BUILD_TYPE=MinSizeRel 
+            -DTorch_INSTALL_DIR="/project/libtorch" 
+            -DTorchVision_INSTALL_DIR="/project/torchvision" 
+            -DProtobuf_INCLUDE_DIR="/project/protobuf/include" 
+            -DProtobuf_LIBRARIES="/project/protobuf/lib64/libprotobuf.a" 
+            -DProtobuf_PROTOC_EXECUTABLE="/project/protobuf/bin/protoc" 
+            -DCMAKE_CXX_COMPILER="/opt/rh/devtoolset-9/root/usr/bin/c++"
+            -DCMAKE_C_COMPILER="/opt/rh/devtoolset-9/root/usr/bin/cc"
+            .. &&
+          cmake --build . -j 2 &&
+          cmake --build . --target install/strip &&
+          cp /project/ncnn/tools/pnnx/build/install/bin/pnnx /project/ncnn/tools/pnnx/python/pnnx
+        CIBW_ENVIRONMENT: PNNX_WHEEL_WITHOUT_BUILD=ON
+        CIBW_REPAIR_WHEEL_COMMAND: ""
+        CIBW_BEFORE_TEST: pip install pytest numpy &&
+                          pip install torch torchvision
+        CIBW_TEST_COMMAND: "pytest {project}/ncnn/tools/pnnx/python/tests"
+      with:
+        package-dir: ./ncnn/tools/pnnx
+        output-dir: wheelhouse
+        
+    - name: Upload wheels
+      uses: actions/upload-artifact@v3
+      with:
+        path: wheelhouse/*.whl
+
+  macos_x86_64:
+    needs: [macos-deps]
+    runs-on: macos-11
+    steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: checkout
+      uses: actions/checkout@v4
+
+    - name: cache-libtorch
+      id: cache-libtorch
+      uses: actions/cache@v3.3.2
+      with:
+        path: "libtorch"
+        key: libtorch-${{ env.LIBTORCH_VERSION }}-macos-${{ env.CACHE_DATE }}
+
+    - name: cache-torchvision
+      id: cache-torchvision
+      uses: actions/cache@v3.3.2
+      with:
+        path: "torchvision"
+        key: torchvision-${{ env.TORCHVISION_VERSION }}-macos-${{ env.CACHE_DATE }}
+
+    - name: cache-protobuf
+      id: cache-protobuf
+      uses: actions/cache@v3.3.2
+      with:
+        path: "protobuf"
+        key: protobuf-${{ env.PROTOBUF_VERSION }}-macos-${{ env.CACHE_DATE }}
+
+    - name: ncnn
+      uses: actions/checkout@v4
+      with:
+        repository: Tencent/ncnn
+        path: ncnn
+
+    - name: build-pnnx
+      run: |
+        cd ncnn/tools/pnnx
+        mkdir build && cd build
+        cmake -DCMAKE_INSTALL_PREFIX=install -DCMAKE_BUILD_TYPE=MinSizeRel \
+            -DTorch_INSTALL_DIR="$GITHUB_WORKSPACE/libtorch" \
+            -DTorchVision_INSTALL_DIR="$GITHUB_WORKSPACE/torchvision" \
+            -DProtobuf_INCLUDE_DIR="$GITHUB_WORKSPACE/protobuf/include" \
+            -DProtobuf_LIBRARIES="$GITHUB_WORKSPACE/protobuf/lib/libprotobuf.a" \
+            -DProtobuf_PROTOC_EXECUTABLE="$GITHUB_WORKSPACE/protobuf/bin/protoc" \
+            ..
+        cmake --build . -j 3
+        cmake --build . --target install/strip
+    - name: copy runtime
+      run: |
+        cp ncnn/tools/pnnx/build/install/bin/pnnx ncnn/tools/pnnx/python/pnnx
+    - name: Build wheels for macos
+      uses: pypa/cibuildwheel@v2.16.2
+      env:
+        CIBW_ARCHS_MACOS: "x86_64"
+        CIBW_BUILD: 'cp*'
+        CIBW_SKIP: cp36-* cp312-*
+        CIBW_BUILD_VERBOSITY: 1
+        CIBW_ENVIRONMENT: PNNX_WHEEL_WITHOUT_BUILD=ON
+        CIBW_REPAIR_WHEEL_COMMAND: ""
+        CIBW_BEFORE_TEST: pip install pytest numpy &&
+                          pip install torch torchvision
+        CIBW_TEST_COMMAND: "pytest {project}/ncnn/tools/pnnx/python/tests"
+      with:
+        package-dir: ./ncnn/tools/pnnx
+        output-dir: wheelhouse
+        
+    - name: Upload wheels
+      uses: actions/upload-artifact@v3
+      with:
+        path: wheelhouse/*.whl
+
+  windows_x86_64:
+    needs: [windows-deps]
+    runs-on: windows-2019
+    env:
+      UseMultiToolTask: true
+    steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: checkout
+      uses: actions/checkout@v4
+
+    - name: cache-libtorch
+      id: cache-libtorch
+      uses: actions/cache@v3.3.2
+      with:
+        path: "libtorch"
+        key: libtorch-${{ env.LIBTORCH_VERSION }}-vs2019-${{ env.CACHE_DATE }}
+
+    - name: cache-torchvision
+      id: cache-torchvision
+      uses: actions/cache@v3.3.2
+      with:
+        path: "torchvision"
+        key: torchvision-${{ env.TORCHVISION_VERSION }}-vs2019-${{ env.CACHE_DATE }}
+
+    - name: cache-protobuf
+      id: cache-protobuf
+      uses: actions/cache@v3.3.2
+      with:
+        path: "protobuf"
+        key: protobuf-${{ env.PROTOBUF_VERSION }}-vs2019-${{ env.CACHE_DATE }}
+
+    - name: ncnn
+      uses: actions/checkout@v4
+      with:
+        repository: Tencent/ncnn
+        path: ncnn
+
+    - name: build-pnnx
+      run: |
+        cd ncnn/tools/pnnx
+        mkdir build && cd build
+        cmake -DCMAKE_INSTALL_PREFIX=install -DPNNX_BUILD_WITH_STATIC_CRT=ON `
+            -DTorch_INSTALL_DIR="$env:GITHUB_WORKSPACE/libtorch" `
+            -DTorchVision_INSTALL_DIR="$env:GITHUB_WORKSPACE/torchvision" `
+            -DProtobuf_INCLUDE_DIR="$env:GITHUB_WORKSPACE/protobuf/include" `
+            -DProtobuf_LIBRARIES="$env:GITHUB_WORKSPACE/protobuf/lib/libprotobuf.lib" `
+            -DProtobuf_PROTOC_EXECUTABLE="$env:GITHUB_WORKSPACE/protobuf/bin/protoc.exe" `
+            ..
+        cmake --build . --config MinSizeRel -j 2
+        cmake --build . --config MinSizeRel --target install
+    - name: copy runtime
+      run: |
+        Copy-Item -Verbose -Path "ncnn\tools\pnnx\build\install\bin\pnnx.exe" -Destination "ncnn\tools\pnnx\python\pnnx\"
+    - name: Build wheels for windows
+      uses: pypa/cibuildwheel@v2.16.2
+      env:
+        CIBW_ARCHS_WINDOWS: "AMD64"
+        CIBW_BUILD: 'cp*'
+        CIBW_SKIP: cp36-* cp312-*
+        CIBW_BUILD_VERBOSITY: 1
+        CIBW_ENVIRONMENT: PNNX_WHEEL_WITHOUT_BUILD=ON
+        CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: ""
+        CIBW_BEFORE_TEST: pip install pytest numpy &&
+                          pip install torch torchvision
+        CIBW_TEST_COMMAND: "pytest D:/a/pnnx/pnnx/ncnn/tools/pnnx/python/tests"
+      with:
+        package-dir: ./ncnn/tools/pnnx
+        output-dir: wheelhouse
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v3
+      with:
+        path: wheelhouse/*.whl
+
+  upload_all:
+    permissions:
+      contents: none
+    name: Upload
+    needs: [ubuntu_x86_64, macos_x86_64, windows_x86_64]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: artifact
+        path: dist
+
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -463,4 +463,5 @@ jobs:
     - uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
This Pull Request introduces the release-python.yml file for the purpose of generating and uploading Python wheels for pnnx. It's important to note that the successful execution of this workflow depends on the prior merge of a related Pull Request in the ncnn project (https://github.com/Tencent/ncnn/pull/5067).

We have conducted release tests across different platforms using pytest, and you can find the results here: https://github.com/Hideousmon/pnnx/actions/runs/6691173863

Note:
The reason for building pnnx in the cibuildwheel environment is that it can't function properly in any of the manylinux1, manylinux2014, manylinux_2_24, and manylinux_2_28 images if it's built in Ubuntu 20.04.